### PR TITLE
Making payment method independent from currency

### DIFF
--- a/example.config.inc.php
+++ b/example.config.inc.php
@@ -5,6 +5,8 @@
 // EUR or USD or even ETH or BTC
 define('CURRENCY','EUR');
 
+define('PAYMENT_METHOD_NAME','EUR Wallet');
+
 // The crypto currency the bot is going to trade.
 // BTC or ETH only the moment
 define('CRYPTO','BTC');

--- a/trader.php
+++ b/trader.php
@@ -155,10 +155,15 @@ class trader
 
         $paymentMethods = $this->client->getPaymentMethods();
 
+        // legacy support so users won't have to change their config
+        if (!defined('PAYMENT_METHOD_NAME')) {
+            define('PAYMENT_METHOD_NAME',CURRENCY.' Wallet');
+        }
+
         //find wallet ID
         foreach($paymentMethods as $pm)
         {
-            if($pm->getName() == CURRENCY.' Wallet')
+            if($pm->getName() == PAYMENT_METHOD_NAME)
             {
                 $this->wallet = $pm;
                 echo "[i] Will use ".$pm->getName()." for payments\n";
@@ -166,7 +171,7 @@ class trader
             }
         }
         if(!$this->wallet)
-            exit("[ERR] Could not find your payment method: '".CURRENCY." Wallet'. Are you sure ".CURRENCY." is a currency?\n");
+            exit("[ERR] Could not find your payment method: '".PAYMENT_METHOD_NAME."'.\n");
 
         echo "\n";
 


### PR DESCRIPTION
Hi,

I made a new payment method name definition in the config file so payment method logic doesn't rely on currency.

In my setup payment method name is completely different from the pattern you've setup (w/c is `CURRENCY + ' Wallet'`)

Mine is something like **"Xfers Account: [MY PHONE NUMBER]"**

so i guess it would be better to just let the user specify this as a separate setting.